### PR TITLE
Accept any `impl Borrow<Triangle>` in `write_stl()`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,10 +144,11 @@ impl IndexedMesh {
 /// let mut binary_stl = Vec::<u8>::new();
 /// stl_io::write_stl(&mut binary_stl, mesh.iter()).unwrap();
 /// ```
-pub fn write_stl<'a, W, I>(writer: &mut W, mesh: I) -> Result<()>
+pub fn write_stl<T, W, I>(writer: &mut W, mesh: I) -> Result<()>
 where
     W: ::std::io::Write,
-    I: ::std::iter::ExactSizeIterator<Item = &'a Triangle>,
+    I: ::std::iter::ExactSizeIterator<Item = T>,
+    T: std::borrow::Borrow<Triangle>,
 {
     let mut writer = BufWriter::new(writer);
 
@@ -155,6 +156,7 @@ where
     writer.write_all(&[0u8; 80])?;
     writer.write_u32::<LittleEndian>(mesh.len() as u32)?;
     for t in mesh {
+        let t = t.borrow();
         for f in &t.normal {
             writer.write_f32::<LittleEndian>(*f as f32)?;
         }


### PR DESCRIPTION
Currently, `write_stl()` requires an iterator that yields items of type `&Triangle`. This is nice if you have a `Vec<Triangle>`, but not so much if you have a container of different objects.

For example:

```
struct MyTriangle { /*...*/ }
impl MyTriangle {
    fn as_stl_triangle(&self) -> stl_io::Triangle { /*...*/ }
}
fn main() {
    let data: Vec<MyTriangle> = /*...*/;
    let mut file = /*...*/;
    stl_io::write_stl(&mut file, data
        .iter()
        .map(|my| my.as_stl_triangle()) // << error!
    ).unwrap();
}
```
Currently this does not work because the given iterator yields values of type `Triangle`, not `&Triangle`. And returning a reference will not work because their lifetime would be that of the `map()` call, so they cannot be returned. I am forced to use `.collect()` and duplicate the memory usage.

The back-compatible solution is to make the iterator yield a generic type that implements `Borrow<Triangle>`, as there are blanket implementations both for `Triangle` and `&Triangle`.