### PR TITLE
add a way to access inner array of Vector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,12 @@ impl<F> Vector<F> {
     }
 }
 
+impl<F> From<Vector<F>> for [F; 3] {
+    fn from(v: Vector<F>) -> Self {
+        v.0
+    }
+}
+
 impl<F> std::ops::Index<usize> for Vector<F> {
     type Output = F;
     fn index(&self, i: usize) -> &Self::Output {


### PR DESCRIPTION
I though it might make sense to make the inner array of a vector accessible. Otherwise it feels a bit awkward to pass those vectors to an API that accepts `[f32; 3]`:

```rust
let position: [f32; 3] = [position[0], position[1], position[2]];
```

Also I think it's impossible to iterate over the components of that vector with the current implementation.

My suggestion is to expose the inner array.

My rather conservative approach in this request is to to offer a `from/into()` implementation which allows the above code to be rewritten into:

```rust
let position: [f32; 3] = position.into();
```

Another approach would be to make the inner field public. That would allow

```rust
let position: [f32; 3] = position.0;
```
or (iirc)
```rust
let Vector(position) = position;
```