### PR TITLE
Update license field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "STL input and output."
 repository = "https://github.com/hmeyer/stl_io"
 readme = "README.md"
 keywords = ["stl", "binary", "ascii", "3d", "mesh"]
-license = "GPL-3.0"
+license = "Apache-2.0 OR MIT"
 
 [lib]
 name = "stl_io"


### PR DESCRIPTION
It seems the license is changed in 0.5.0 (https://github.com/hmeyer/stl_io/commit/8818e4c59d00fde47d100be6e25b113ebb921028), but Cargo.toml still mentions the previous license.

Some license analysis tools refer to the license field in Cargo.toml, so it may be interpreted as still being licensed under GPL-3.