### PR TITLE
Make `Vector::new` const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Vector<F>([F; 3]);
 
 impl<F> Vector<F> {
     /// Constructor from array.
-    pub fn new(v: [F; 3]) -> Self {
+    pub const fn new(v: [F; 3]) -> Self {
         Self(v)
     }
 }


### PR DESCRIPTION
Allows making `const` vectors/triangles/etc. The following code no longer fails to compile:

```rust
const I_HAT: Vector<f32> = Vector::new([1., 0., 0.]);

const TRI: Triangle = Triangle {
    normal: I_HAT,
    vertices: [
        Vertex::new([0.0, -1.0, 0.0]),
        Vertex::new([0.0, 1.0, 0.0]),
        Vertex::new([0.0, 0.0, 0.5]),
    ],
};
```
